### PR TITLE
Disable CORS credentials for wildcard origins

### DIFF
--- a/app.py
+++ b/app.py
@@ -122,7 +122,7 @@ app = FastAPI(title="Arohi Backend", version="0.1.0")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"] if ALLOWED_ORIGINS == ["*"] else ALLOWED_ORIGINS,
-    allow_credentials=True,
+    allow_credentials=ALLOWED_ORIGINS != ["*"],
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
## Summary
- avoid sending credentials when allowed origins is a wildcard

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c66095dd7083289e2fae64e9d34a07